### PR TITLE
limits for league search page

### DIFF
--- a/routes/leaguesearch.js
+++ b/routes/leaguesearch.js
@@ -58,7 +58,7 @@ var fetchGoatLists = function(callback){
       var all_leagues = createTeamLists(result);
       var sorted_teams = sortTeams(all_leagues);  // Sort the teams within each league by number of quizzes taken
     }
-    callback(null,sorted_teams);  
+    callback(null, sorted_teams);  
   }); 
 }
 
@@ -86,8 +86,9 @@ var fetchGoatListsByLeague = function(league,callback){
             teams.push(team);
           }
         sorted_teams = teams.sort(compareCounts);
+        subset = sorted_teams.slice(0,10);
       }
-      callback(null, sorted_teams);  
+      callback(null, subset);  
   })
 }
 
@@ -156,8 +157,9 @@ var createTeamLists = function(teamobject){
 var sortTeams = function(teamsobject){
   for (var key in teamsobject){
     teamsobject[key].sort(compareCounts);
+    var limited = teamsobject[key].slice(0,10);
   }
-  return teamsobject
+  return limited
 }
 
 

--- a/routes/leaguesearch.js
+++ b/routes/leaguesearch.js
@@ -51,14 +51,26 @@ var fetchGoatLists = function(callback){
         "quiz_name": "$quiz_name"
       },
       "quizCount": { "$sum": 1}
-    }}
+    }}, {
+      $sort: {quizCount: -1}
+    }, {
+      $limit: 10
+    }
 
   ], function (err, result){ 
-    if (result.length > 0){
-      var all_leagues = createTeamLists(result);
-      var sorted_teams = sortTeams(all_leagues);  // Sort the teams within each league by number of quizzes taken
-    }
-    callback(null, sorted_teams);  
+      if (result.length > 0){
+        teams = [];
+        for (i=0;i<Object.keys(result).length;i++){
+            var team = {};
+            team.rb_team_id = result[i]._id.rb_team_id;
+            team.league = result[i]._id.league;
+            team.team_name = result[i]._id.quiz_name;
+            team.quizCount = result[i].quizCount;
+            teams.push(team);
+          }
+        console.log("TEAMS"+teams);
+      }
+    callback(null, teams);  
   }); 
 }
 
@@ -157,9 +169,8 @@ var createTeamLists = function(teamobject){
 var sortTeams = function(teamsobject){
   for (var key in teamsobject){
     teamsobject[key].sort(compareCounts);
-    var limited = teamsobject[key].slice(0,10);
   }
-  return limited
+  return teamsobject
 }
 
 

--- a/routes/leaguesearch.js
+++ b/routes/leaguesearch.js
@@ -52,9 +52,9 @@ var fetchGoatLists = function(callback){
       },
       "quizCount": { "$sum": 1}
     }}, {
-      $sort: {quizCount: -1}
+      "$sort": {"quizCount": -1}
     }, {
-      $limit: 10
+      "$limit": 10
     }
 
   ], function (err, result){ 
@@ -74,21 +74,26 @@ var fetchGoatLists = function(callback){
   }); 
 }
 
-var fetchGoatListsByLeague = function(league,callback){
+var fetchGoatListsByLeague = function(league, callback){
 	db.collection('quiz').aggregate(
     [{ "$match" : {"$and" : [{ "created_at" : { "$gt" : quizCutoffDate.toISOString().slice(0, 19).replace('T', ' ') }}, {"league" : league} ] }
     },
-    { "$group": {
-        "_id": {
-          "rb_team_id": "$rb_team_id",
-          "league": "$league",
-          "quiz_name": "$quiz_name"
-        },
-        "quizCount": { "$sum": 1}
-      }
-    }], function(err, result){
+  { "$group": {
+      "_id": {
+        "rb_team_id": "$rb_team_id",
+        "league": "$league",
+        "quiz_name": "$quiz_name"
+      },
+      "quizCount": { "$sum": 1}
+    }}, {
+      "$sort": {"quizCount": -1}
+    }, {
+      "$limit": 10
+    }
+
+  ], function (err, result){
+      teams = []; 
       if (result.length > 0){
-        teams = [];
         for (i=0;i<Object.keys(result).length;i++){
             var team = {};
             team.rb_team_id = result[i]._id.rb_team_id;
@@ -97,10 +102,9 @@ var fetchGoatListsByLeague = function(league,callback){
             team.quizCount = result[i].quizCount;
             teams.push(team);
           }
-        sorted_teams = teams.sort(compareCounts);
-        subset = sorted_teams.slice(0,10);
+        console.log("TEAMS"+teams);
       }
-      callback(null, subset);  
+    callback(null, teams);  
   })
 }
 
@@ -121,57 +125,6 @@ router.get('/:league', function(req, res) {
 
 })
 
-
-var createTeamLists = function(teamobject){
-  var teams = {};
-  var nba_teams = [];
-  var nfl_teams = [];
-  var eu_soccer_teams = [];
-  var nhl_teams = [];
-  var goats_teams = [];
-  var mlb_teams = [];
-  for (i=0;i<Object.keys(teamobject).length;i++){
-    var team = {};
-    team.rb_team_id = teamobject[i]._id.rb_team_id;
-    team.league = teamobject[i]._id.league;
-    team.team_name = teamobject[i]._id.quiz_name;
-    team.quizCount = teamobject[i].quizCount;
-    switch (team.league){
-      case 'nba':
-        nba_teams.push(team);        
-        break;
-      case 'goats':
-        goats_teams.push(team);        
-        break;
-      case 'eu_soccer':
-        eu_soccer_teams.push(team);        
-        break;
-      case 'nhl':
-        nhl_teams.push(team);        
-        break;
-      case 'nfl':
-        nfl_teams.push(team);        
-        break;
-      case 'mlb':
-        mlb_teams.push(team);        
-    }}
-    teams.nba=nba_teams;
-    teams.goats_teams=goats_teams;
-    teams.eu_soccer_teams = eu_soccer_teams;
-    teams.nhl_teams=nhl_teams;
-    teams.nfl_teams = nfl_teams;
-    teams.mlb_teams = mlb_teams;
-  return teams
-}
-
-
-
-var sortTeams = function(teamsobject){
-  for (var key in teamsobject){
-    teamsobject[key].sort(compareCounts);
-  }
-  return teamsobject
-}
 
 
 function compareCounts(a,b) {


### PR DESCRIPTION
@blakeparkinson Plow, your self merge earlier broke the rendering stuff for popular teams on /leaguesearch

I didn't figure it out in this commit, but this will limit the returns of popular teams to 10 for both general and individual league pages. 

BC there is sorting after mongo, we just do it outside of all the mongo calls.