### PR TITLE
make percentile more optimistic

### DIFF
--- a/routes/quiz.js
+++ b/routes/quiz.js
@@ -123,22 +123,26 @@ var redirectQuiz = function(item, res){
    res.end();
 }
 
-/* Takes in a sorted array that includes the historical scores and the new score. Sorted position over length = percentile. 
-Am ignoring true math piece of even/odd stuff */
+/* Takes in a sorted array that includes the historical scores and the new score. Sorted position / length = percentile. 
+Optimistic way of calculating. Ex scores 0,1,1,2,3 and you scored one of the 1's, you will be in the 60th percentile. */
 var calculatePercentile = function(req, score, all_scores){
   len = all_scores.length;
   count = 0;
   for (i=0;i<all_scores.length;i++){
-    if(all_scores[i]< score){
+    if (len == 1){ // if you're the first taker, you get 100th percentile
+      req.session.scores.percentile = 1
+      return;
+    }
+    else if(all_scores[i]<= score && count < len -1){
       count++
     }
-    else if (all_scores[i] == score){
+    else if (all_scores[i]<= score && count == len - 1){
+      count++
       percentile = (count/len)*100
       req.session.scores.percentile = percentile
       return;
     }
-    else if (all_scores[i] > score){
-      // this is bad and we should never actually hit this case.
+    else if (all_scores[i]> score){
       percentile = (count/len)*100
       req.session.scores.percentile = percentile
       return;


### PR DESCRIPTION
Change the calculations so that user gets top of percentile range instead of bottom. 

Example. All scores are: 0, 1, 1, 2, 5 and you scored one of the 1's. 

You will now be marked as 3/5 percentile, or 60 percentile. (previously you would have received 2/5 or 40 percentile). 

Also put in an edge case for first quiz taker gets 100 percentile